### PR TITLE
Add country whitelist filter (allow only specific countries)

### DIFF
--- a/conduit.sh
+++ b/conduit.sh
@@ -1673,12 +1673,10 @@ process_batch() {
             if (c == "") c = "Unknown"
             if (dir == "FROM") from_bytes[c] += bytes
             else to_bytes[c] += bytes
-            # Also collect snapshot lines
             print dir "|" c "|" bytes "|" ip > snap
             next
         }
         END {
-            # Merge existing + new
             for (c in existing) {
                 split(existing[c], v, "|")
                 f = v[1] + 0; t = v[2] + 0
@@ -1688,7 +1686,6 @@ process_batch() {
                 delete from_bytes[c]
                 delete to_bytes[c]
             }
-            # New countries not in existing
             for (c in from_bytes) {
                 f = from_bytes[c] + 0
                 t = to_bytes[c] + 0


### PR DESCRIPTION
## Summary
Adds an optional country whitelist so Conduit only accepts connections from selected countries (e.g. Iran). Non-whitelisted IPs are blocked via ipset + iptables on Conduit ports (TCP 443, UDP 16384–32768) only; other services on the host are unchanged.

## Features
- **Whitelist config** (`/opt/conduit/allowed_countries.conf`): one country per line; empty/missing = allow all.
- **Blocking**: Reactive (1–2 s after first packet); uses existing GeoIP (geoiplookup/mmdblookup) + ip-api.com fallback for Unknown IPs.
- **Unknown IPs**: Default = accept (no geolocation = allowed). Optional `BLOCK_UNKNOWN=yes` to block them.
- **Menu**: Settings → "Configure country filter" — edit whitelist, add country, clear whitelist, view blocked log, clear ipset, Unknown accept/block toggle, refresh GeoIP cache, trim blocked log.
- **CLI**: `conduit filter` opens country filter config.
- **Log rotation**: `blocked_ips.log` auto-trims when >10k lines (keeps last 5k); option to trim/clear manually.
- **Uninstall**: Removes iptables rules, ipset, and config.

## Verification
- `sudo iptables -L INPUT -n -v | grep conduit_blocked` — see DROP counts.
- `sudo ipset list conduit_blocked` — see blocklist.
- `cat /opt/conduit/traffic_stats/blocked_ips.log` — see blocked IPs and countries.