### PR TITLE
Fix alpine docker installation

### DIFF
--- a/conduit.sh
+++ b/conduit.sh
@@ -553,7 +553,7 @@ install_docker() {
     fi
 
     if [ "$OS_FAMILY" = "alpine" ]; then
-        if ! setup-apkrepos -c &>/dev/null; then
+        if ! setup-apkrepos -c -1 &>/dev/null; then
             log_error "Failed to enable community repository on Alpine"
         fi
         


### PR DESCRIPTION
Docker only exists on the "community" repo in Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86_64/docker

Here we enable the community repos before attempting to install docker. The only caveat is that we choose the CDN mirror for the community repo: https://wiki.alpinelinux.org/wiki/Alpine_configuration_management_scripts#setup-apkrepos

This is because the `setup-apkrepos` is an interactive command unless the `-1` flag is provided to select the first listed mirror which is the CDN.

I have tested this on VM and it works smoothly.